### PR TITLE
feat: Enable full XPath 2.0 support for XSD 1.1 CTA expressions

### DIFF
--- a/xmlvalidator-common/src/main/java/eu/europa/ec/itb/xml/util/Utils.java
+++ b/xmlvalidator-common/src/main/java/eu/europa/ec/itb/xml/util/Utils.java
@@ -86,6 +86,9 @@ public class Utils {
         try (var schemaStream = Files.newInputStream(schemaToValidateWith)) {
             factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
             factory.setFeature(Constants.XERCES_FEATURE_PREFIX + Constants.SCHEMA_FULL_CHECKING, true);
+            if (schemaVersionToUse == XmlSchemaVersion.VERSION_1_1) {
+                factory.setFeature(Constants.XERCES_FEATURE_PREFIX + "validation/cta-full-xpath-checking", true);
+            }
             schema = factory.newSchema(new StreamSource(schemaStream));
         } catch (SAXException e) {
             throw new IllegalStateException("Unable to configure schema", e);

--- a/xmlvalidator-common/src/main/java/eu/europa/ec/itb/xml/util/Utils.java
+++ b/xmlvalidator-common/src/main/java/eu/europa/ec/itb/xml/util/Utils.java
@@ -87,7 +87,7 @@ public class Utils {
             factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
             factory.setFeature(Constants.XERCES_FEATURE_PREFIX + Constants.SCHEMA_FULL_CHECKING, true);
             if (schemaVersionToUse == XmlSchemaVersion.VERSION_1_1) {
-                factory.setFeature(Constants.XERCES_FEATURE_PREFIX + "validation/cta-full-xpath-checking", true);
+                factory.setFeature(Constants.XERCES_FEATURE_PREFIX + Constants.CTA_FULL_XPATH_CHECKING_FEATURE, true);
             }
             schema = factory.newSchema(new StreamSource(schemaStream));
         } catch (SAXException e) {

--- a/xmlvalidator-common/src/test/java/eu/europa/ec/itb/xml/util/UtilsTest.java
+++ b/xmlvalidator-common/src/test/java/eu/europa/ec/itb/xml/util/UtilsTest.java
@@ -161,4 +161,35 @@ class UtilsTest {
             }
         });
     }
+
+    @Test
+    void testSchemaValidationXsd11CtaFullXPathValid() {
+        assertDoesNotThrow(() -> {
+            try (
+                    var inputStream = Thread.currentThread().getContextClassLoader().getResourceAsStream("utils/testFiles/valid_cta.xml");
+                    var schemaStream = Thread.currentThread().getContextClassLoader().getResourceAsStream("utils/CtaXPath.xsd")
+            ) {
+                Path schemaPath = tempDirectory.resolve(UUID.randomUUID() + ".xsd");
+                Files.copy(Objects.requireNonNull(schemaStream), schemaPath);
+                secureSchemaValidation(inputStream, schemaPath, null, null, null, XmlSchemaVersion.VERSION_1_1);
+            }
+        });
+    }
+
+    @Test
+    void testSchemaValidationXsd11CtaFullXPathInvalid() throws SAXException {
+        // With error handler.
+        var errorHandler = mock(ErrorHandler.class);
+        assertDoesNotThrow(() -> {
+            try (
+                    var inputStream = Thread.currentThread().getContextClassLoader().getResourceAsStream("utils/testFiles/invalid_cta.xml");
+                    var schemaStream = Thread.currentThread().getContextClassLoader().getResourceAsStream("utils/CtaXPath.xsd")
+            ) {
+                Path schemaPath = tempDirectory.resolve(UUID.randomUUID() + ".xsd");
+                Files.copy(Objects.requireNonNull(schemaStream), schemaPath);
+                secureSchemaValidation(inputStream, schemaPath, errorHandler, null, null, XmlSchemaVersion.VERSION_1_1);
+            }
+        });
+        verify(errorHandler, atLeastOnce()).error(any(SAXParseException.class));
+    }
 }

--- a/xmlvalidator-common/src/test/resources/utils/CtaXPath.xsd
+++ b/xmlvalidator-common/src/test/resources/utils/CtaXPath.xsd
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+           xmlns:vc="http://www.w3.org/2007/XMLSchema-versioning"
+           vc:minVersion="1.1"
+           elementFormDefault="qualified">
+
+    <xs:element name="item">
+        <xs:alternative test="not(@optional)" type="RequiredItem"/>
+        <xs:alternative test="xsd:string(@status) eq 'active'" type="ActiveItem"/>
+        <xs:alternative test="@id and not(xsd:string(@id) eq '00000000-0000-0000-0000-000000000000')" type="IdentifiedItem"/>
+        <xs:alternative type="BaseItem"/>
+    </xs:element>
+
+    <xs:complexType name="BaseItem">
+        <xs:attribute name="optional" type="xs:string"/>
+        <xs:attribute name="status"   type="xs:string"/>
+        <xs:attribute name="id"       type="xs:string"/>
+    </xs:complexType>
+
+    <xs:complexType name="RequiredItem">
+        <xs:complexContent>
+            <xs:extension base="BaseItem">
+                <xs:sequence>
+                    <xs:element name="name" type="xs:string"/>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="ActiveItem">
+        <xs:complexContent>
+            <xs:extension base="BaseItem">
+                <xs:sequence>
+                    <xs:element name="name" type="xs:string" minOccurs="0"/>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="IdentifiedItem">
+        <xs:complexContent>
+            <xs:extension base="BaseItem">
+                <xs:sequence>
+                    <xs:element name="name" type="xs:string" minOccurs="0"/>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+</xs:schema>

--- a/xmlvalidator-common/src/test/resources/utils/testFiles/invalid_cta.xml
+++ b/xmlvalidator-common/src/test/resources/utils/testFiles/invalid_cta.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<item id="550e8400-e29b-41d4-a716-446655440000"/>

--- a/xmlvalidator-common/src/test/resources/utils/testFiles/valid_cta.xml
+++ b/xmlvalidator-common/src/test/resources/utils/testFiles/valid_cta.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<item id="550e8400-e29b-41d4-a716-446655440000">
+    <name>Test item</name>
+</item>


### PR DESCRIPTION
Hi, the tool looks really promising, but i had a problem with a xsd 1.1 schema with a more complex cta xpath check. For that i had to enable the Xerces cta-full-xpath-checking flag. 

I dont know if you are open to contributions, but this is how i fixed it to work with my xsd. I also added a small test as an example. 

BR Fabian